### PR TITLE
Fix Jekyll build errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,11 +6,11 @@ keywords: Technology, MachineLearning, DataMining, Wiki
 description: A wiki website
 author: zhang787jun
 root: /Wiki
-theme: simple
+theme: themes/simple
 debug: True
 destination: output
 source: content
 attach: attach
 default_ext: md
-pygments: true
+highlighter: rouge
 # theme add MathJax.js


### PR DESCRIPTION
This commit addresses two issues in the Jekyll build process:

1.  Updates the deprecated `pygments` highlighter setting to `highlighter: rouge` in `_config.yml`.
2.  Specifies the local theme path directly in `_config.yml` by changing `theme: simple` to `theme: themes/simple`. This ensures the build process can locate the theme files within the repository.

These changes should resolve the deprecation warnings and theme-not-found errors previously occurring in the GitHub Pages build.