### PR TITLE
Fix deploy config mutation in Fabric task

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -136,7 +136,7 @@ def deploy(type=None):
     done = False
 
     for deploy_item in deploy_configs:
-        deploy_type = deploy_item.pop('type')
+        deploy_type = deploy_item.get('type')
         if type and deploy_type != type:
             continue
         func_name = 'deploy_{0}'.format(deploy_type)


### PR DESCRIPTION
## Summary
- stop removing `type` from deploy configuration in Fabric script

## Testing
- `python -m py_compile fabfile.py`
- `python -m py_compile attach/opencv/tf_text_graph_common.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68405e84aca08325b8e551bb2315a823)