### PR TITLE
Fix GitHub Pages deployment for Simiki

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,44 +1,42 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy Simiki to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          source: ./
-          destination: ./_site
+          python-version: "3.11"
+      - name: Install Simiki
+        run: |
+          python -m pip install --upgrade pip
+          pip install simiki
+      - name: Build site
+        run: |
+          simiki g
+          touch output/.nojekyll
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: output
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
### Motivation
- Replace the Jekyll-based Pages workflow with a Simiki build so the repository publishes the actual generated site output.
- Ensure the static `output` directory is uploaded and served correctly by adding a `.nojekyll` marker.
- Use a Python setup step to install `simiki` and run the site generation as part of the CI workflow.

### Description
- Replaced `.github/workflows/jekyll-gh-pages.yml` contents to change the job from a Jekyll build to a Simiki build and deployment.
- Added `actions/setup-python@v5` and an `Install Simiki` step that runs `pip install simiki` and then `simiki g` to generate the site.
- Create a `.nojekyll` marker with `touch output/.nojekyll` and upload the generated `output` directory using `actions/upload-pages-artifact@v3` with `path: output`.
- Kept the `deploy` job using `actions/deploy-pages@v4` to publish the uploaded artifact to GitHub Pages.

### Testing
- No automated tests were run in this change because it is a workflow-only update.
- The workflow will be validated automatically by GitHub Actions when triggered on `push` to `master` or via `workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698810d241108325b4a8dd3021fac8e1)