### PR TITLE
Fix FTP upload file handle leak, correct deploy warning typo, and add rsync config test

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -108,8 +108,8 @@ def deploy_ftp(deploy_configs):
         rel_root = os.path.relpath(root, output_dir)
         for fn in files:
             store_fn = os.path.join(ftp_dir, rel_root, fn)
-            ftp.storbinary('STOR %s' % store_fn,
-                           open(os.path.join(root, fn), 'rb'))
+            with open(os.path.join(root, fn), 'rb') as upload_file:
+                ftp.storbinary('STOR %s' % store_fn, upload_file)
 
     ftp.close()
 
@@ -142,7 +142,7 @@ def deploy(type=None):
         func_name = 'deploy_{0}'.format(deploy_type)
         func = globals().get(func_name)
         if not func:
-            do_exit('Warning: not supprt {0} deploy method'
+            do_exit('Warning: not support {0} deploy method'
                     .format(deploy_type))
         func(deploy_item)
         done = True

--- a/tests/test_fabfile.py
+++ b/tests/test_fabfile.py
@@ -1,0 +1,70 @@
+import contextlib
+import pathlib
+import sys
+import types
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+fabric_module = types.ModuleType("fabric")
+fabric_api = types.ModuleType("fabric.api")
+fabric_colors = types.ModuleType("fabric.colors")
+fabric_contrib = types.ModuleType("fabric.contrib")
+fabric_contrib_project = types.ModuleType("fabric.contrib.project")
+simiki_module = types.ModuleType("simiki")
+simiki_config = types.ModuleType("simiki.config")
+simiki_compat = types.ModuleType("simiki.compat")
+
+
+@contextlib.contextmanager
+def _settings(*args, **kwargs):
+    yield
+
+
+def _task(func=None, *args, **kwargs):
+    if func is None:
+        return lambda inner: inner
+    return func
+
+
+def _local(*args, **kwargs):
+    return None
+
+
+fabric_api.env = types.SimpleNamespace()
+fabric_api.local = _local
+fabric_api.task = _task
+fabric_api.settings = _settings
+fabric_colors.blue = lambda message: message
+fabric_colors.red = lambda message: message
+fabric_contrib_project.rsync_project = lambda *args, **kwargs: None
+simiki_config.parse_config = lambda *args, **kwargs: {}
+simiki_compat.raw_input = lambda *args, **kwargs: ""
+
+sys.modules["fabric"] = fabric_module
+sys.modules["fabric.api"] = fabric_api
+sys.modules["fabric.colors"] = fabric_colors
+sys.modules["fabric.contrib"] = fabric_contrib
+sys.modules["fabric.contrib.project"] = fabric_contrib_project
+sys.modules["simiki"] = simiki_module
+sys.modules["simiki.config"] = simiki_config
+sys.modules["simiki.compat"] = simiki_compat
+
+import fabfile
+
+
+def test_get_rsync_configs_returns_rsync_entry(monkeypatch):
+    sample_configs = {
+        "deploy": [
+            {"type": "ftp", "host": "ftp.example.com"},
+            {"type": "rsync", "host": "rsync.example.com"},
+            {"type": "git", "remote": "origin"},
+        ]
+    }
+
+    monkeypatch.setattr(fabfile, "configs", sample_configs)
+
+    assert fabfile.get_rsync_configs() == {
+        "type": "rsync",
+        "host": "rsync.example.com",
+    }


### PR DESCRIPTION
### Motivation
- Prevent leaking file descriptors during FTP deploy by ensuring uploaded files are closed after use.
- Correct a spelling mistake in the runtime warning to make messages clearer for users and maintainers.
- Add a unit test for `get_rsync_configs` to increase confidence in deploy configuration selection.

### Description
- Updated `deploy_ftp` in `fabfile.py` to open files with a context manager (`with open(..., 'rb') as upload_file:`) before calling `ftp.storbinary` so each file is closed after upload.
- Fixed the unsupported deploy type message in `fabfile.py` to use `not support {0} deploy method` instead of the misspelled version.
- Added `tests/test_fabfile.py` which stubs optional dependencies (`fabric` and `simiki`) to allow importing `fabfile`, and includes a `pytest` test that patches `fabfile.configs` and asserts `get_rsync_configs()` returns the `rsync` entry.

### Testing
- Ran `pytest -q` in the repository root and the test suite passed: `1 passed in 0.34s`.
- Verified the modified `deploy_ftp` logic via static inspection and ensured the repository imports succeed in the test environment by stubbing optional modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68405e856f588325a0e4e10391820eb9)